### PR TITLE
feat: CI + recent tables on home + /join/:code invite alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Typecheck + build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared packages
+        run: pnpm build:shared
+
+      # Game modules are resolved by the server via their dist/ output (the
+      # server's register-games.ts imports `@bgo/games-*/server`), so every
+      # game package needs to be built before the server can typecheck.
+      - name: Build game modules
+        run: pnpm --filter "@bgo/games-*" build
+
+      - name: Typecheck (all packages)
+        run: pnpm -r typecheck
+
+      - name: Build web
+        run: pnpm --filter @bgo/web build
+
+      - name: Build server
+        run: pnpm --filter @bgo/server build

--- a/packages/web/src/app/join/[code]/page.tsx
+++ b/packages/web/src/app/join/[code]/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ensurePlayer, getStoredName, storeName } from "@/lib/playerSession";
+
+/**
+ * Shareable invite alias: /join/:code.
+ *
+ * If the visitor already has a stored name, we forward straight to the lobby.
+ * Otherwise we prompt once for a name, persist it, then forward. Invalid join
+ * codes (not 4 letters) bounce home with ?invalidJoin=<code>.
+ */
+export default function JoinPage() {
+  const router = useRouter();
+  const params = useParams();
+  const rawCode =
+    typeof params.code === "string" ? params.code.toUpperCase() : "";
+  const code = rawCode.trim();
+  const validCode = /^[A-Z]{4}$/.test(code);
+
+  const [checked, setChecked] = useState(false);
+  const [needsName, setNeedsName] = useState(false);
+  const [nameInput, setNameInput] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!validCode) {
+      router.replace(`/?invalidJoin=${encodeURIComponent(rawCode || "")}`);
+      return;
+    }
+    const stored = getStoredName();
+    if (stored && stored.trim().length > 0) {
+      router.replace(`/lobby/${code}`);
+      return;
+    }
+    setNeedsName(true);
+    setChecked(true);
+  }, [router, code, rawCode, validCode]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = nameInput.trim();
+    if (!name) {
+      setError("Please enter a name.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      storeName(name);
+      await ensurePlayer(name);
+      router.replace(`/lobby/${code}`);
+    } catch (err) {
+      setError((err as Error).message);
+      setSubmitting(false);
+    }
+  };
+
+  if (!checked || !needsName) {
+    return (
+      <div className="max-w-md mx-auto mt-24 px-6 flex flex-col items-center gap-4">
+        <div className="flex gap-1.5">
+          {[0, 1, 2].map((i) => (
+            <span
+              key={i}
+              className="h-2 w-2 rounded-full bg-primary"
+              style={{
+                animation: "parlorWinPulse 1.2s ease-in-out infinite",
+                animationDelay: `${i * 0.12}s`,
+              }}
+            />
+          ))}
+        </div>
+        <div className="text-sm text-base-content/60 uppercase tracking-[0.2em]">
+          Taking you to the table…
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-md mx-auto px-5 md:px-8 pt-10 md:pt-16 pb-20 flex flex-col gap-8">
+      <section className="flex flex-col items-center gap-5 text-center parlor-rise">
+        <div className="rule-ornament">
+          <span className="rule-ornament-line" />
+          <span>◆ You're invited ◆</span>
+          <span className="rule-ornament-line" />
+        </div>
+        <h1
+          className="font-display leading-[1.05]"
+          style={{ fontSize: "var(--text-display-sm)" }}
+        >
+          Joining table{" "}
+          <span className="font-mono tracking-[0.2em] text-primary">{code}</span>
+        </h1>
+        <p className="text-base-content/65 max-w-sm">
+          Pick a name others will see. It saves to this device — no account
+          needed.
+        </p>
+      </section>
+
+      <form
+        onSubmit={submit}
+        className="surface-ivory p-5 md:p-6 flex flex-col gap-5 parlor-rise"
+        style={{ animationDelay: "80ms" }}
+      >
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="join-name-input"
+            className="text-[10px] font-semibold uppercase tracking-[0.22em] text-base-content/55"
+          >
+            Your name
+          </label>
+          <input
+            id="join-name-input"
+            type="text"
+            autoFocus
+            placeholder="How should others see you?"
+            className="w-full bg-transparent border-0 outline-none font-display text-xl placeholder:text-base-content/30 placeholder:font-sans placeholder:text-base"
+            value={nameInput}
+            onChange={(e) => setNameInput(e.target.value)}
+            maxLength={40}
+          />
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="border border-error/40 bg-error/10 text-error px-3 py-2 rounded-lg text-sm"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-3">
+          <button
+            type="button"
+            className="text-xs uppercase tracking-[0.2em] text-base-content/50 hover:text-base-content transition-colors"
+            onClick={() => router.replace("/")}
+          >
+            ← Home
+          </button>
+          <button
+            type="submit"
+            className="btn btn-primary rounded-full px-6 font-semibold tracking-wide"
+            disabled={submitting || nameInput.trim().length === 0}
+          >
+            {submitting ? (
+              <span className="loading loading-spinner loading-xs" />
+            ) : (
+              "Take me in →"
+            )}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/web/src/app/lobby/[joinCode]/page.tsx
+++ b/packages/web/src/app/lobby/[joinCode]/page.tsx
@@ -7,6 +7,7 @@ import { getClientModule } from "@bgo/sdk-client";
 import { api } from "@/lib/apiClient";
 import { ensurePlayer, getStoredName, storeName } from "@/lib/playerSession";
 import { registerAllClientGames } from "@/lib/registerClientGames";
+import { recordRecentTable } from "@/lib/recentTables";
 import { PlayerAvatar } from "@/components/PlayerAvatar";
 import { JoinCodeDisplay } from "@/components/JoinCodeDisplay";
 
@@ -59,6 +60,11 @@ export default function LobbyPage() {
         const r = await api.joinTable(joinCode);
         if (cancelled) return;
         setTable(r.table);
+        recordRecentTable({
+          tableId: r.table.id,
+          joinCode: r.table.joinCode,
+          gameType: r.table.gameType,
+        });
         schedulePoll(r.table.id);
       } catch (err) {
         if (!cancelled) setError((err as Error).message);

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import type { GameCategoryWire, GameMetaWire } from "@bgo/contracts";
 import { api } from "@/lib/apiClient";
 import { ensurePlayer, getStoredName, storeName } from "@/lib/playerSession";
+import {
+  getRecentTables,
+  removeRecentTable,
+  type RecentTable,
+} from "@/lib/recentTables";
 import { GameIcon } from "@/components/GameIcon";
 
 // Dev-only: exposes the one-click "fully-seated debug table" flow. Next.js
@@ -14,11 +19,15 @@ const DEBUG_MODE = process.env.NODE_ENV !== "production";
 
 export default function Home() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [games, setGames] = useState<GameMetaWire[] | null>(null);
   const [name, setName] = useState<string>("");
   const [joinCode, setJoinCode] = useState<string>("");
   const [pending, setPending] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [recent, setRecent] = useState<RecentTable[]>([]);
+
+  const invalidJoin = searchParams?.get("invalidJoin");
 
   useEffect(() => {
     api
@@ -26,6 +35,33 @@ export default function Home() {
       .then((r) => setGames(r.games))
       .catch((err) => setError((err as Error).message));
     setName(getStoredName() ?? "");
+    setRecent(getRecentTables());
+  }, []);
+
+  // Probe each recent entry — drop any whose table has been evicted server-side.
+  useEffect(() => {
+    const initial = getRecentTables();
+    if (initial.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      const results = await Promise.all(
+        initial.map(async (entry) => {
+          try {
+            await api.getTable(entry.tableId);
+            return { entry, alive: true };
+          } catch {
+            return { entry, alive: false };
+          }
+        }),
+      );
+      if (cancelled) return;
+      const dead = results.filter((r) => !r.alive).map((r) => r.entry.joinCode);
+      for (const code of dead) removeRecentTable(code);
+      setRecent(getRecentTables());
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const saveName = async (n: string) => {
@@ -178,6 +214,27 @@ export default function Home() {
         >
           {error}
         </div>
+      )}
+
+      {invalidJoin && (
+        <div
+          role="alert"
+          className="-mt-8 border border-warning/40 bg-warning/10 text-warning-content px-4 py-3 rounded-lg text-sm"
+        >
+          We couldn't find a table for{" "}
+          <span className="font-mono uppercase tracking-[0.18em]">
+            {invalidJoin.toUpperCase() || "that link"}
+          </span>
+          . Double-check the code and try again.
+        </div>
+      )}
+
+      {recent.length > 0 && (
+        <RecentTablesSection
+          recent={recent}
+          games={games}
+          onOpen={(code) => router.push(`/lobby/${code}`)}
+        />
       )}
 
       {/* ============ Catalog ============ */}
@@ -485,6 +542,104 @@ function CatalogSkeleton() {
       ))}
     </ul>
   );
+}
+
+function RecentTablesSection({
+  recent,
+  games,
+  onOpen,
+}: {
+  recent: RecentTable[];
+  games: GameMetaWire[] | null;
+  onOpen: (joinCode: string) => void;
+}) {
+  const byType = useMemo(() => {
+    const map = new Map<string, GameMetaWire>();
+    for (const g of games ?? []) map.set(g.type, g);
+    return map;
+  }, [games]);
+
+  return (
+    <section className="flex flex-col gap-5 parlor-rise">
+      <div className="flex items-baseline justify-between gap-4 flex-wrap">
+        <div className="rule-ornament" style={{ justifyContent: "flex-start" }}>
+          <span>◆ Pick up where you left off</span>
+          <span className="rule-ornament-line" />
+        </div>
+        <span className="font-mono text-[11px] tabular uppercase tracking-[0.22em] text-base-content/45 whitespace-nowrap">
+          {recent.length} recent
+        </span>
+      </div>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {recent.map((entry, i) => {
+          const meta = byType.get(entry.gameType);
+          const label = meta?.displayName ?? prettyGameType(entry.gameType);
+          return (
+            <li
+              key={entry.joinCode}
+              className="parlor-rise rise-stagger"
+              style={{ ["--i" as string]: i }}
+            >
+              <button
+                type="button"
+                onClick={() => onOpen(entry.joinCode)}
+                className={[
+                  "group w-full text-left",
+                  "surface-ivory",
+                  "px-4 py-3.5",
+                  "transition-all duration-200",
+                  "hover:-translate-y-0.5 hover:shadow-[var(--shadow-float)]",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+                  "flex items-center gap-3",
+                ].join(" ")}
+              >
+                <GameIcon type={entry.gameType} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-2">
+                    <span className="font-mono tracking-[0.22em] text-base text-primary">
+                      {entry.joinCode}
+                    </span>
+                    <span
+                      aria-hidden
+                      className="text-primary font-semibold text-sm transition-transform group-hover:translate-x-1 ml-auto"
+                    >
+                      →
+                    </span>
+                  </div>
+                  <div className="flex items-baseline justify-between gap-2 mt-0.5">
+                    <span className="font-display text-base truncate">
+                      {label}
+                    </span>
+                    <span className="text-[11px] tabular uppercase tracking-[0.18em] text-base-content/45 shrink-0">
+                      {relativeTime(entry.visitedAt)}
+                    </span>
+                  </div>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function prettyGameType(type: string): string {
+  return type
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function relativeTime(timestamp: number, now: number = Date.now()): string {
+  const diff = Math.max(0, now - timestamp);
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
 }
 
 function Step({

--- a/packages/web/src/lib/recentTables.ts
+++ b/packages/web/src/lib/recentTables.ts
@@ -1,0 +1,88 @@
+"use client";
+
+/**
+ * Client-side store for recently-visited tables. Persisted to localStorage so
+ * the home page can surface a short "pick up where you left off" list. We keep
+ * the most-recent 5 entries, dedupe on join code, and expire anything older
+ * than 24 hours.
+ */
+
+const STORAGE_KEY = "bgo.recentTables";
+const MAX_ENTRIES = 5;
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface RecentTable {
+  tableId: string;
+  joinCode: string;
+  gameType: string;
+  visitedAt: number;
+}
+
+function readRaw(): RecentTable[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is RecentTable =>
+        !!e &&
+        typeof e === "object" &&
+        typeof (e as RecentTable).tableId === "string" &&
+        typeof (e as RecentTable).joinCode === "string" &&
+        typeof (e as RecentTable).gameType === "string" &&
+        typeof (e as RecentTable).visitedAt === "number",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeRaw(entries: RecentTable[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+function prune(entries: RecentTable[], now: number): RecentTable[] {
+  return entries
+    .filter((e) => now - e.visitedAt < TTL_MS)
+    .sort((a, b) => b.visitedAt - a.visitedAt)
+    .slice(0, MAX_ENTRIES);
+}
+
+/** Returns recent tables (fresh, sorted newest-first, capped). */
+export function getRecentTables(now: number = Date.now()): RecentTable[] {
+  const pruned = prune(readRaw(), now);
+  writeRaw(pruned);
+  return pruned;
+}
+
+/** Insert-or-update a recent table entry. Dedupes on join code. */
+export function recordRecentTable(entry: {
+  tableId: string;
+  joinCode: string;
+  gameType: string;
+}): void {
+  if (typeof window === "undefined") return;
+  const now = Date.now();
+  const code = entry.joinCode.toUpperCase();
+  const existing = readRaw().filter((e) => e.joinCode.toUpperCase() !== code);
+  const next = prune(
+    [{ ...entry, joinCode: code, visitedAt: now }, ...existing],
+    now,
+  );
+  writeRaw(next);
+}
+
+/** Remove a recent table by join code (e.g. after a 404 probe). */
+export function removeRecentTable(joinCode: string): void {
+  if (typeof window === "undefined") return;
+  const code = joinCode.toUpperCase();
+  const next = readRaw().filter((e) => e.joinCode.toUpperCase() !== code);
+  writeRaw(next);
+}


### PR DESCRIPTION
## Summary

Three small, independent shipments bundled as one PR:

- **CI workflow** (`.github/workflows/ci.yml`): Node 20 + pnpm 9 on `push`/`pull_request` (to master). Installs with frozen lockfile, builds shared + game modules, typechecks every workspace, then builds web and server. Game modules are built ahead of typecheck because `packages/server/src/games/register-games.ts` resolves `@bgo/games-*/server` through each package's `dist/` output.
- **Recent tables on home**: new `packages/web/src/lib/recentTables.ts` localStorage helper (5 entries, 24h TTL, dedupe on join code). Lobby page records each visit; home probes via `api.getTable` and evicts any entry that 404s. "Pick up where you left off" strip uses existing `surface-ivory` + `GameIcon` + `parlor-rise` — no new visual primitives.
- **/join/:code invite alias**: new `packages/web/src/app/join/[code]/page.tsx`. Forwards to `/lobby/:code` if a stored name exists; otherwise prompts once for a name. Invalid codes (not 4 letters) redirect to `/?invalidJoin=<code>`, which home surfaces as a warning banner.

### Decisions

- The server exposes `GET /tables/:id` (by UUID) but no `GET /tables/byCode/:code`. The recent-tables store keeps both `tableId` and `joinCode`, probes by id, and navigates by code.
- `/join/:code` doesn't pre-fetch the table — the lobby page already calls `joinTable` with its own error handling, so an extra HEAD-style probe would be redundant (and there isn't a side-effect-free one by code anyway).
- CI is a single Node 20 job. No matrix — the brief allowed skipping it, and wall time is the priority.

## Test plan

- [ ] PR shows a green CI check.
- [ ] Break a type on a new branch → CI turns red.
- [ ] Visit 3 lobbies, navigate home → "Pick up where you left off" shows all 3, newest-first.
- [ ] Clicking an entry routes to `/lobby/<code>`.
- [ ] Leave a 25h-old localStorage entry → it disappears on next home load.
- [ ] Visit `/join/WXYZ` with no stored name → name form; submit → `/lobby/WXYZ`.
- [ ] Visit `/join/WXYZ` with stored name → forwards immediately.
- [ ] Visit `/join/abc` (invalid) → redirects to `/` with warning banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)