### PR TITLE
test: tic-tac-toe reference + match-service unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ lerna-debug.log*
 # Tests
 /coverage
 /.nyc_output
+**/coverage/
 
 # IDEs and editors
 /.idea

--- a/packages/games-tictactoe/jest.config.cjs
+++ b/packages/games-tictactoe/jest.config.cjs
@@ -1,0 +1,26 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  rootDir: 'src',
+  testEnvironment: 'node',
+  testRegex: '.*\\.spec\\.ts$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  transform: {
+    '^.+\\.(t|j)sx?$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          jsx: 'react-jsx',
+          esModuleInterop: true,
+          moduleResolution: 'node',
+          module: 'commonjs',
+          target: 'ES2022',
+          strict: true,
+          skipLibCheck: true,
+          resolveJsonModule: true,
+        },
+      },
+    ],
+  },
+  collectCoverageFrom: ['server.ts'],
+  coverageDirectory: '../coverage',
+};

--- a/packages/games-tictactoe/package.json
+++ b/packages/games-tictactoe/package.json
@@ -35,10 +35,13 @@
     "react": ">=19"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@types/node": "^22.13.10",
     "@types/react": "^19.0.10",
+    "jest": "^29.7.0",
     "react": "^19.0.0",
     "rimraf": "^6.0.1",
+    "ts-jest": "^29.2.6",
     "typescript": "^5.8.2"
   }
 }

--- a/packages/games-tictactoe/src/server.spec.ts
+++ b/packages/games-tictactoe/src/server.spec.ts
@@ -1,0 +1,440 @@
+import type { GameContext, GameEvent, Player, PlayerId } from "@bgo/sdk";
+import { createRng } from "@bgo/sdk";
+import { ticTacToeServerModule } from "./server";
+import type { TicTacToeMove, TicTacToeState } from "./shared";
+
+/**
+ * Reference test fixture pattern for game modules. Other game packages should
+ * copy this shape: a synthetic GameContext with a fixed seed + a synthetic
+ * clock, no real timers, and helpers that build deterministic initial state.
+ */
+
+interface HarnessOptions {
+  seed?: number;
+  now?: number;
+}
+
+interface Harness {
+  ctx: GameContext;
+  scheduled: Array<{ key: string; at: number }>;
+  cancelled: string[];
+  emitted: GameEvent[];
+}
+
+function makeCtx(opts: HarnessOptions = {}): Harness {
+  const scheduled: Array<{ key: string; at: number }> = [];
+  const cancelled: string[] = [];
+  const emitted: GameEvent[] = [];
+  const ctx: GameContext = {
+    version: 0,
+    now: opts.now ?? 1_700_000_000_000,
+    rng: createRng(opts.seed ?? 42),
+    scheduleTimer(key, at) {
+      scheduled.push({ key, at });
+    },
+    cancelTimer(key) {
+      cancelled.push(key);
+    },
+    emit(event) {
+      emitted.push(event);
+    },
+  };
+  return { ctx, scheduled, cancelled, emitted };
+}
+
+const ALICE: Player = { id: "p-alice", name: "Alice" };
+const BOB: Player = { id: "p-bob", name: "Bob" };
+
+/**
+ * Two fixed seeds chosen so `ctx.rng()` returns the values that trigger each
+ * branch of `createInitialState`'s xFirst coin flip. Seed 7 puts Alice on X;
+ * seed 42 puts Bob on X. No reliance on Math.random anywhere.
+ */
+const SEED_ALICE_X = 7;
+const SEED_BOB_X = 42;
+
+function stateWhereAliceIsX(): {
+  state: TicTacToeState;
+  x: PlayerId;
+  o: PlayerId;
+} {
+  const { ctx } = makeCtx({ seed: SEED_ALICE_X });
+  const state = ticTacToeServerModule.createInitialState(
+    [ALICE, BOB],
+    {},
+    ctx,
+  );
+  expect(state.symbols[ALICE.id]).toBe("X");
+  return { state, x: ALICE.id, o: BOB.id };
+}
+
+function stateWhereBobIsX(): {
+  state: TicTacToeState;
+  x: PlayerId;
+  o: PlayerId;
+} {
+  const { ctx } = makeCtx({ seed: SEED_BOB_X });
+  const state = ticTacToeServerModule.createInitialState(
+    [ALICE, BOB],
+    {},
+    ctx,
+  );
+  expect(state.symbols[BOB.id]).toBe("X");
+  return { state, x: BOB.id, o: ALICE.id };
+}
+
+/** Play out a sequence of moves, returning the final state. Asserts each ok. */
+function play(
+  initial: TicTacToeState,
+  moves: Array<{ actor: PlayerId; cellIndex: number }>,
+): TicTacToeState {
+  const { ctx } = makeCtx();
+  let state = initial;
+  for (const m of moves) {
+    const move: TicTacToeMove = { kind: "place", cellIndex: m.cellIndex };
+    const result = ticTacToeServerModule.handleMove(state, move, m.actor, ctx);
+    if (!result.ok) {
+      throw new Error(`expected ok, got rejection: ${result.reason}`);
+    }
+    state = result.state;
+  }
+  return state;
+}
+
+describe("ticTacToeServerModule", () => {
+  describe("metadata", () => {
+    it("exposes stable metadata", () => {
+      expect(ticTacToeServerModule.type).toBe("tic-tac-toe");
+      expect(ticTacToeServerModule.minPlayers).toBe(2);
+      expect(ticTacToeServerModule.maxPlayers).toBe(2);
+      expect(ticTacToeServerModule.category).toBe("classic");
+    });
+  });
+
+  describe("defaultConfig / validateConfig", () => {
+    it("defaultConfig returns empty object", () => {
+      expect(ticTacToeServerModule.defaultConfig()).toEqual({});
+    });
+
+    it("validateConfig accepts undefined, null, and {}", () => {
+      expect(ticTacToeServerModule.validateConfig(undefined)).toEqual({});
+      expect(ticTacToeServerModule.validateConfig(null)).toEqual({});
+      expect(ticTacToeServerModule.validateConfig({})).toEqual({});
+    });
+
+    it("validateConfig rejects non-object configs", () => {
+      expect(() => ticTacToeServerModule.validateConfig(7)).toThrow();
+      expect(() => ticTacToeServerModule.validateConfig("foo")).toThrow();
+    });
+  });
+
+  describe("createInitialState", () => {
+    it("builds a 3x3 empty board", () => {
+      const { state } = stateWhereAliceIsX();
+      expect(state.cells).toHaveLength(9);
+      expect(state.cells.every((c) => c === null)).toBe(true);
+    });
+
+    it("assigns one X and one O, and the X player goes first", () => {
+      const { state, x } = stateWhereAliceIsX();
+      const symbols = Object.values(state.symbols).sort();
+      expect(symbols).toEqual(["O", "X"]);
+      expect(state.current).toBe(x);
+      expect(state.winner).toBeNull();
+      expect(state.isDraw).toBe(false);
+    });
+
+    it("the seeded rng determines who is X (both branches exercised)", () => {
+      const a = stateWhereAliceIsX();
+      const b = stateWhereBobIsX();
+      expect(a.state.symbols[ALICE.id]).toBe("X");
+      expect(b.state.symbols[BOB.id]).toBe("X");
+    });
+
+    it("throws when player count is not exactly 2", () => {
+      const { ctx } = makeCtx();
+      expect(() =>
+        ticTacToeServerModule.createInitialState([ALICE], {}, ctx),
+      ).toThrow(/exactly 2 players/);
+      expect(() =>
+        ticTacToeServerModule.createInitialState(
+          [ALICE, BOB, { id: "p-c", name: "C" }],
+          {},
+          ctx,
+        ),
+      ).toThrow(/exactly 2 players/);
+    });
+  });
+
+  describe("handleMove", () => {
+    it("accepts a valid move, updates cell, swaps current", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      const { ctx } = makeCtx();
+      const result = ticTacToeServerModule.handleMove(
+        state,
+        { kind: "place", cellIndex: 4 },
+        x,
+        ctx,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.state.cells[4]).toBe("X");
+      expect(result.state.current).toBe(o);
+      // Original state is untouched — handleMove returns new state.
+      expect(state.cells[4]).toBeNull();
+    });
+
+    it("rejects out-of-turn moves", () => {
+      const { state, o } = stateWhereAliceIsX();
+      const { ctx } = makeCtx();
+      const result = ticTacToeServerModule.handleMove(
+        state,
+        { kind: "place", cellIndex: 0 },
+        o,
+        ctx,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toMatch(/turn/i);
+    });
+
+    it("rejects a move into a taken cell", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      const after = play(state, [{ actor: x, cellIndex: 0 }]);
+      const { ctx } = makeCtx();
+      const result = ticTacToeServerModule.handleMove(
+        after,
+        { kind: "place", cellIndex: 0 },
+        o,
+        ctx,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toMatch(/taken/i);
+    });
+
+    it("rejects out-of-bounds cell indices via schema", () => {
+      const { state, x } = stateWhereAliceIsX();
+      const { ctx } = makeCtx();
+      for (const cellIndex of [-1, 9, 42]) {
+        const result = ticTacToeServerModule.handleMove(
+          state,
+          { kind: "place", cellIndex } as TicTacToeMove,
+          x,
+          ctx,
+        );
+        expect(result.ok).toBe(false);
+        if (result.ok) continue;
+        expect(result.reason).toMatch(/malformed/i);
+      }
+    });
+
+    it("rejects malformed move (missing kind)", () => {
+      const { state, x } = stateWhereAliceIsX();
+      const { ctx } = makeCtx();
+      const result = ticTacToeServerModule.handleMove(
+        state,
+        { cellIndex: 0 } as unknown as TicTacToeMove,
+        x,
+        ctx,
+      );
+      expect(result.ok).toBe(false);
+    });
+
+    it("rejects moves after the game is over", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      // X wins top row.
+      const terminal = play(state, [
+        { actor: x, cellIndex: 0 },
+        { actor: o, cellIndex: 3 },
+        { actor: x, cellIndex: 1 },
+        { actor: o, cellIndex: 4 },
+        { actor: x, cellIndex: 2 },
+      ]);
+      expect(terminal.winner).toBe(x);
+
+      const { ctx } = makeCtx();
+      const result = ticTacToeServerModule.handleMove(
+        terminal,
+        { kind: "place", cellIndex: 5 },
+        o,
+        ctx,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toMatch(/over/i);
+    });
+
+    it("rejects a move from someone who isn't in the match", () => {
+      // Craft a state whose `current` points at an unknown id — the
+      // `symbols[actor]` lookup then fails.
+      const { state, x } = stateWhereAliceIsX();
+      const rigged: TicTacToeState = { ...state, current: "p-ghost" };
+      const { ctx } = makeCtx();
+      const result = ticTacToeServerModule.handleMove(
+        rigged,
+        { kind: "place", cellIndex: 0 },
+        "p-ghost",
+        ctx,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toMatch(/not in this match/i);
+    });
+  });
+
+  describe("view", () => {
+    it("returns an identical view for each player and spectator (no hidden info)", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      const mid = play(state, [
+        { actor: x, cellIndex: 0 },
+        { actor: o, cellIndex: 4 },
+      ]);
+      const xView = ticTacToeServerModule.view(mid, x);
+      const oView = ticTacToeServerModule.view(mid, o);
+      const specView = ticTacToeServerModule.view(mid, "spectator");
+      expect(xView).toEqual(oView);
+      expect(oView).toEqual(specView);
+    });
+
+    it("populates winningLine when someone has won", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      const terminal = play(state, [
+        { actor: x, cellIndex: 0 },
+        { actor: o, cellIndex: 3 },
+        { actor: x, cellIndex: 1 },
+        { actor: o, cellIndex: 4 },
+        { actor: x, cellIndex: 2 },
+      ]);
+      const v = ticTacToeServerModule.view(terminal, "spectator");
+      expect(v.winningLine).toEqual([0, 1, 2]);
+      expect(v.winner).toBe(x);
+    });
+
+    it("winningLine is null mid-game", () => {
+      const { state, x } = stateWhereAliceIsX();
+      const mid = play(state, [{ actor: x, cellIndex: 0 }]);
+      const v = ticTacToeServerModule.view(mid, "spectator");
+      expect(v.winningLine).toBeNull();
+    });
+
+    it("view.cells is a fresh array (not shared with state)", () => {
+      const { state } = stateWhereAliceIsX();
+      const v = ticTacToeServerModule.view(state, "spectator");
+      expect(v.cells).not.toBe(state.cells);
+    });
+  });
+
+  describe("outcome / isTerminal / phase", () => {
+    it("returns null outcome mid-game, play phase, current actor present", () => {
+      const { state, x } = stateWhereAliceIsX();
+      expect(ticTacToeServerModule.outcome(state)).toBeNull();
+      expect(ticTacToeServerModule.isTerminal(state)).toBe(false);
+      expect(ticTacToeServerModule.phase(state)).toBe("play");
+      expect(ticTacToeServerModule.currentActors(state)).toEqual([x]);
+    });
+
+    it("detects a row win (solo outcome, terminal, gameOver phase, no actors)", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      const s = play(state, [
+        { actor: x, cellIndex: 0 },
+        { actor: o, cellIndex: 3 },
+        { actor: x, cellIndex: 1 },
+        { actor: o, cellIndex: 4 },
+        { actor: x, cellIndex: 2 },
+      ]);
+      const out = ticTacToeServerModule.outcome(s);
+      expect(out).toEqual({ kind: "solo", winners: [x], losers: [o] });
+      expect(ticTacToeServerModule.isTerminal(s)).toBe(true);
+      expect(ticTacToeServerModule.phase(s)).toBe("gameOver");
+      expect(ticTacToeServerModule.currentActors(s)).toEqual([]);
+    });
+
+    it("detects a column win", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      const s = play(state, [
+        { actor: x, cellIndex: 0 },
+        { actor: o, cellIndex: 1 },
+        { actor: x, cellIndex: 3 },
+        { actor: o, cellIndex: 4 },
+        { actor: x, cellIndex: 6 },
+      ]);
+      expect(ticTacToeServerModule.outcome(s)).toEqual({
+        kind: "solo",
+        winners: [x],
+        losers: [o],
+      });
+    });
+
+    it("detects a diagonal win (main diagonal)", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      const s = play(state, [
+        { actor: x, cellIndex: 0 },
+        { actor: o, cellIndex: 1 },
+        { actor: x, cellIndex: 4 },
+        { actor: o, cellIndex: 2 },
+        { actor: x, cellIndex: 8 },
+      ]);
+      expect(s.winner).toBe(x);
+      expect(ticTacToeServerModule.outcome(s)).toEqual({
+        kind: "solo",
+        winners: [x],
+        losers: [o],
+      });
+    });
+
+    it("detects an anti-diagonal win", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      const s = play(state, [
+        { actor: x, cellIndex: 2 },
+        { actor: o, cellIndex: 0 },
+        { actor: x, cellIndex: 4 },
+        { actor: o, cellIndex: 1 },
+        { actor: x, cellIndex: 6 },
+      ]);
+      expect(s.winner).toBe(x);
+    });
+
+    it("detects a draw when the board is full with no winner", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      // X O X
+      // X O O
+      // O X X   -> no line of three
+      const s = play(state, [
+        { actor: x, cellIndex: 0 },
+        { actor: o, cellIndex: 1 },
+        { actor: x, cellIndex: 2 },
+        { actor: o, cellIndex: 4 },
+        { actor: x, cellIndex: 3 },
+        { actor: o, cellIndex: 6 },
+        { actor: x, cellIndex: 7 },
+        { actor: o, cellIndex: 5 },
+        { actor: x, cellIndex: 8 },
+      ]);
+      expect(s.winner).toBeNull();
+      expect(s.isDraw).toBe(true);
+      expect(ticTacToeServerModule.outcome(s)).toEqual({ kind: "draw" });
+      expect(ticTacToeServerModule.isTerminal(s)).toBe(true);
+    });
+
+    it("isTerminal iff outcome is non-null (the SDK invariant)", () => {
+      const { state, x, o } = stateWhereAliceIsX();
+      const mid = play(state, [
+        { actor: x, cellIndex: 0 },
+        { actor: o, cellIndex: 4 },
+      ]);
+      const terminal = play(state, [
+        { actor: x, cellIndex: 0 },
+        { actor: o, cellIndex: 3 },
+        { actor: x, cellIndex: 1 },
+        { actor: o, cellIndex: 4 },
+        { actor: x, cellIndex: 2 },
+      ]);
+      for (const s of [state, mid, terminal]) {
+        expect(ticTacToeServerModule.isTerminal(s)).toBe(
+          ticTacToeServerModule.outcome(s) !== null,
+        );
+      }
+    });
+  });
+});

--- a/packages/games-tictactoe/src/server.spec.ts
+++ b/packages/games-tictactoe/src/server.spec.ts
@@ -268,7 +268,7 @@ describe("ticTacToeServerModule", () => {
     it("rejects a move from someone who isn't in the match", () => {
       // Craft a state whose `current` points at an unknown id — the
       // `symbols[actor]` lookup then fails.
-      const { state, x } = stateWhereAliceIsX();
+      const { state } = stateWhereAliceIsX();
       const rigged: TicTacToeState = { ...state, current: "p-ghost" };
       const { ctx } = makeCtx();
       const result = ticTacToeServerModule.handleMove(

--- a/packages/games-tictactoe/tsconfig.json
+++ b/packages/games-tictactoe/tsconfig.json
@@ -6,5 +6,6 @@
     "rootDir": "./src",
     "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.spec.tsx"]
 }

--- a/packages/server/src/match/__fixtures__/counter-game.ts
+++ b/packages/server/src/match/__fixtures__/counter-game.ts
@@ -1,0 +1,190 @@
+import type {
+  GameContext,
+  GameEvent,
+  GameModule,
+  MoveResult,
+  Outcome,
+  PhaseId,
+  Player,
+  PlayerId,
+  Viewer,
+} from '@bgo/sdk';
+
+/**
+ * Minimal 2-player "counter" game used exclusively by match.service.spec.ts
+ * so the test suite has no dependency on any real game package. Players take
+ * turns pressing +1; first to hit the target (default 3) wins. Includes an
+ * onTimer handler so the timer path can be exercised.
+ *
+ * Also exposes two knobs the tests tweak at runtime:
+ *  - `failNextMove`: reject the next handleMove with the given reason
+ *  - `scheduleTimerOnNextMove`: schedule a timer with the given key + at
+ * Both are one-shot and clear themselves after firing.
+ */
+export interface CounterState {
+  order: PlayerId[];
+  currentIdx: number;
+  count: number;
+  target: number;
+  winner: PlayerId | null;
+  lastTimerKey: string | null;
+  phaseName: 'play' | 'gameOver';
+}
+
+export type CounterMove =
+  | { kind: 'increment' }
+  | { kind: 'invalid'; raw: unknown };
+
+export type CounterConfig = { target: number };
+
+export type CounterView = Omit<CounterState, 'lastTimerKey'>;
+
+interface CounterKnobs {
+  failNextMove: string | null;
+  scheduleTimerOnNextMove: { key: string; at: number } | null;
+  emitOnNextMove: { kind: string } | null;
+  phaseChangeOnCount: number | null;
+}
+
+export const counterKnobs: CounterKnobs = {
+  failNextMove: null,
+  scheduleTimerOnNextMove: null,
+  emitOnNextMove: null,
+  phaseChangeOnCount: null,
+};
+
+export function resetCounterKnobs(): void {
+  counterKnobs.failNextMove = null;
+  counterKnobs.scheduleTimerOnNextMove = null;
+  counterKnobs.emitOnNextMove = null;
+  counterKnobs.phaseChangeOnCount = null;
+}
+
+export const COUNTER_GAME_TYPE = 'counter-game';
+
+export const counterGameModule: GameModule<
+  CounterState,
+  CounterMove,
+  CounterConfig,
+  CounterView
+> = {
+  type: COUNTER_GAME_TYPE,
+  displayName: 'Counter',
+  description: 'Test fixture: players take turns incrementing a counter.',
+  category: 'classic',
+  minPlayers: 2,
+  maxPlayers: 2,
+
+  defaultConfig(): CounterConfig {
+    return { target: 3 };
+  },
+
+  validateConfig(cfg: unknown): CounterConfig {
+    if (cfg && typeof cfg === 'object' && 'target' in cfg) {
+      const t = (cfg as { target: unknown }).target;
+      if (typeof t === 'number' && t > 0) return { target: t };
+    }
+    return { target: 3 };
+  },
+
+  createInitialState(
+    players: Player[],
+    cfg: CounterConfig,
+    _ctx: GameContext,
+  ): CounterState {
+    return {
+      order: players.map((p) => p.id),
+      currentIdx: 0,
+      count: 0,
+      target: cfg.target,
+      winner: null,
+      lastTimerKey: null,
+      phaseName: 'play',
+    };
+  },
+
+  handleMove(
+    state: CounterState,
+    move: CounterMove,
+    actor: PlayerId,
+    ctx: GameContext,
+  ): MoveResult<CounterState> {
+    if (state.winner) return { ok: false, reason: 'Game is over' };
+    if (state.order[state.currentIdx] !== actor) {
+      return { ok: false, reason: 'Not your turn' };
+    }
+    if (move.kind !== 'increment') {
+      return { ok: false, reason: 'Malformed move' };
+    }
+    if (counterKnobs.failNextMove !== null) {
+      const reason = counterKnobs.failNextMove;
+      counterKnobs.failNextMove = null;
+      return { ok: false, reason };
+    }
+
+    if (counterKnobs.scheduleTimerOnNextMove) {
+      const { key, at } = counterKnobs.scheduleTimerOnNextMove;
+      counterKnobs.scheduleTimerOnNextMove = null;
+      ctx.scheduleTimer(key, at);
+    }
+    const events: GameEvent[] = [];
+    if (counterKnobs.emitOnNextMove) {
+      const { kind } = counterKnobs.emitOnNextMove;
+      counterKnobs.emitOnNextMove = null;
+      events.push({ kind, to: 'all' });
+    }
+
+    const nextCount = state.count + 1;
+    const winner = nextCount >= state.target ? actor : null;
+    const nextPhase =
+      counterKnobs.phaseChangeOnCount === nextCount || winner
+        ? 'gameOver'
+        : state.phaseName;
+    if (counterKnobs.phaseChangeOnCount === nextCount) {
+      counterKnobs.phaseChangeOnCount = null;
+    }
+    return {
+      ok: true,
+      state: {
+        ...state,
+        count: nextCount,
+        currentIdx: (state.currentIdx + 1) % state.order.length,
+        winner,
+        phaseName: nextPhase,
+      },
+      events: events.length > 0 ? events : undefined,
+    };
+  },
+
+  onTimer(
+    state: CounterState,
+    key: string,
+    _ctx: GameContext,
+  ): MoveResult<CounterState> {
+    return { ok: true, state: { ...state, lastTimerKey: key } };
+  },
+
+  view(state: CounterState, _viewer: Viewer): CounterView {
+    const { lastTimerKey: _lt, ...pub } = state;
+    return pub;
+  },
+
+  phase(state: CounterState): PhaseId {
+    return state.phaseName;
+  },
+
+  currentActors(state: CounterState): PlayerId[] {
+    if (state.winner) return [];
+    return [state.order[state.currentIdx]!];
+  },
+
+  isTerminal(state: CounterState): boolean {
+    return state.winner !== null;
+  },
+
+  outcome(state: CounterState): Outcome | null {
+    if (!state.winner) return null;
+    const losers = state.order.filter((id) => id !== state.winner);
+    return { kind: 'solo', winners: [state.winner], losers };
+  },
+};

--- a/packages/server/src/match/match.service.spec.ts
+++ b/packages/server/src/match/match.service.spec.ts
@@ -1,0 +1,316 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import type { MatchId, PlayerId, RuntimeViewer } from '@bgo/sdk';
+
+import { MatchService } from './match.service';
+import { GamesRegistry } from '../games/games-registry.service';
+import { TablesService } from '../tables/tables.service';
+import { PlayersService } from '../players/players.service';
+import { LobbyStore, StoredPlayer } from '../state/lobby-store.service';
+import { InMemoryStateStore } from '../state/in-memory-state-store.service';
+import {
+  COUNTER_GAME_TYPE,
+  CounterState,
+  CounterView,
+  counterGameModule,
+  counterKnobs,
+  resetCounterKnobs,
+} from './__fixtures__/counter-game';
+
+/**
+ * Unit tests for the match-service core. Wires the real service against real
+ * in-memory helpers, but registers only a test-fixture counter game (see
+ * __fixtures__/counter-game.ts) so the suite stays isolated from any real
+ * game package. Timers go through the real InMemoryStateStore so the test
+ * exercises the live scheduleTimer → onTimer path.
+ */
+
+interface Fixture {
+  service: MatchService;
+  registry: GamesRegistry;
+  tables: TablesService;
+  players: PlayersService;
+  lobby: LobbyStore;
+  store: InMemoryStateStore;
+  host: StoredPlayer;
+  guest: StoredPlayer;
+}
+
+async function buildFixture(): Promise<Fixture> {
+  resetCounterKnobs();
+  const mod: TestingModule = await Test.createTestingModule({
+    providers: [
+      MatchService,
+      GamesRegistry,
+      TablesService,
+      PlayersService,
+      LobbyStore,
+      InMemoryStateStore,
+      { provide: 'StateStore', useExisting: InMemoryStateStore },
+    ],
+  }).compile();
+  // Exercise the real OnModuleInit so the store → matchService timer callback
+  // is wired up. Without init(), onTimer never fires.
+  await mod.init();
+
+  const registry = mod.get(GamesRegistry);
+  registry.register(counterGameModule);
+
+  const service = mod.get(MatchService);
+  const players = mod.get(PlayersService);
+  const tables = mod.get(TablesService);
+  const lobby = mod.get(LobbyStore);
+  const store = mod.get(InMemoryStateStore);
+
+  const host = players.create('Host');
+  const guest = players.create('Guest');
+
+  return { service, registry, tables, players, lobby, store, host, guest };
+}
+
+async function startCounterMatch(
+  fx: Fixture,
+  configOverride?: unknown,
+): Promise<{ matchId: MatchId; host: PlayerId; guest: PlayerId }> {
+  const table = fx.tables.create(COUNTER_GAME_TYPE, fx.host.id);
+  fx.tables.join(table.joinCode, fx.guest.id);
+  if (configOverride !== undefined) {
+    fx.tables.updateConfig(table.id, fx.host.id, configOverride);
+  }
+  const started = await fx.service.startMatch(table.id, fx.host.id);
+  return {
+    matchId: started.matchId!,
+    host: fx.host.id,
+    guest: fx.guest.id,
+  };
+}
+
+async function getView(
+  fx: Fixture,
+  matchId: MatchId,
+  viewer: RuntimeViewer,
+): Promise<{
+  view: CounterView;
+  phase: string;
+  currentActors: PlayerId[];
+  isTerminal: boolean;
+  version: number;
+  outcome: unknown;
+}> {
+  const v = await fx.service.getView(matchId, viewer);
+  if (!v) throw new Error('expected view');
+  return v as {
+    view: CounterView;
+    phase: string;
+    currentActors: PlayerId[];
+    isTerminal: boolean;
+    version: number;
+    outcome: unknown;
+  };
+}
+
+describe('MatchService', () => {
+  describe('handleMove (happy path)', () => {
+    it('applies a valid move: state updates and version increments', async () => {
+      const fx = await buildFixture();
+      const { matchId, host } = await startCounterMatch(fx);
+
+      const before = await getView(fx, matchId, host);
+      expect(before.version).toBe(0);
+      expect(before.view.count).toBe(0);
+      expect(before.currentActors).toEqual([host]);
+
+      const result = await fx.service.submitMove(matchId, host, {
+        kind: 'increment',
+      });
+      expect(result).toEqual({ ok: true });
+
+      const after = await getView(fx, matchId, host);
+      expect(after.version).toBe(1);
+      expect(after.view.count).toBe(1);
+      expect(after.currentActors).toEqual([fx.guest.id]);
+    });
+
+    it('notifies subscribers on state change', async () => {
+      const fx = await buildFixture();
+      const { matchId, host } = await startCounterMatch(fx);
+
+      const views: CounterView[] = [];
+      const unsub = fx.service.subscribeViews(matchId, host, (v) => {
+        views.push(v.view as CounterView);
+      });
+
+      await fx.service.submitMove(matchId, host, { kind: 'increment' });
+      expect(views).toHaveLength(1);
+      expect(views[0]!.count).toBe(1);
+      unsub();
+    });
+
+    it('emits game events to registered listeners', async () => {
+      const fx = await buildFixture();
+      const { matchId, host } = await startCounterMatch(fx);
+
+      const received: Array<{ matchId: MatchId; kind: string }> = [];
+      const unsub = fx.service.subscribeEvents((mid, ev) => {
+        received.push({ matchId: mid, kind: ev.kind });
+      });
+
+      counterKnobs.emitOnNextMove = { kind: 'test-event' };
+      const result = await fx.service.submitMove(matchId, host, {
+        kind: 'increment',
+      });
+      expect(result).toEqual({ ok: true });
+      expect(received).toEqual([{ matchId, kind: 'test-event' }]);
+      unsub();
+    });
+  });
+
+  describe('handleMove (rejections)', () => {
+    it('rejects an out-of-turn actor with the game-module reason', async () => {
+      const fx = await buildFixture();
+      const { matchId, guest } = await startCounterMatch(fx);
+      const result = await fx.service.submitMove(matchId, guest, {
+        kind: 'increment',
+      });
+      expect(result).toEqual({ ok: false, reason: 'Not your turn' });
+    });
+
+    it('surfaces a game-reports-ok-false rejection verbatim', async () => {
+      const fx = await buildFixture();
+      const { matchId, host } = await startCounterMatch(fx);
+      counterKnobs.failNextMove = 'Malformed move payload';
+      const result = await fx.service.submitMove(matchId, host, {
+        kind: 'increment',
+      });
+      expect(result).toEqual({ ok: false, reason: 'Malformed move payload' });
+    });
+
+    it('rejects moves once the match is terminal', async () => {
+      const fx = await buildFixture();
+      // Target 1 → the very first increment ends the match.
+      const { matchId, host, guest } = await startCounterMatch(fx, {
+        target: 1,
+      });
+      const first = await fx.service.submitMove(matchId, host, {
+        kind: 'increment',
+      });
+      expect(first).toEqual({ ok: true });
+
+      const terminalView = await getView(fx, matchId, 'spectator');
+      expect(terminalView.isTerminal).toBe(true);
+      expect(terminalView.outcome).toEqual({
+        kind: 'solo',
+        winners: [host],
+        losers: [guest],
+      });
+
+      const after = await fx.service.submitMove(matchId, guest, {
+        kind: 'increment',
+      });
+      expect(after).toEqual({ ok: false, reason: 'Game is over' });
+    });
+
+    it('rejects handleMove throws as a safe internal-error rejection', async () => {
+      const fx = await buildFixture();
+      const { matchId, host } = await startCounterMatch(fx);
+      // Mutate the module to simulate an internal throw.
+      const original = counterGameModule.handleMove;
+      counterGameModule.handleMove = () => {
+        throw new Error('boom');
+      };
+      try {
+        const result = await fx.service.submitMove(matchId, host, {
+          kind: 'increment',
+        });
+        expect(result).toEqual({
+          ok: false,
+          reason: 'Internal error processing move',
+        });
+      } finally {
+        counterGameModule.handleMove = original;
+      }
+    });
+
+    it('throws a forbidden error when actor is not a participant', async () => {
+      const fx = await buildFixture();
+      const { matchId } = await startCounterMatch(fx);
+      await expect(
+        fx.service.submitMove(matchId, 'p-stranger', { kind: 'increment' }),
+      ).rejects.toThrow(/participant/i);
+    });
+  });
+
+  describe('phase transitions', () => {
+    it('surfaces a new phase on subscribed views when the module advances phase', async () => {
+      const fx = await buildFixture();
+      const { matchId, host } = await startCounterMatch(fx);
+
+      counterKnobs.phaseChangeOnCount = 1;
+      const phases: string[] = [];
+      const unsub = fx.service.subscribeViews(matchId, host, (v) => {
+        phases.push(v.phase);
+      });
+
+      await fx.service.submitMove(matchId, host, { kind: 'increment' });
+      expect(phases).toEqual(['gameOver']);
+      unsub();
+    });
+  });
+
+  describe('terminal detection + outcome surfacing', () => {
+    it('marks the table finished and freezes the view', async () => {
+      const fx = await buildFixture();
+      const { matchId, host, guest } = await startCounterMatch(fx, {
+        target: 1,
+      });
+      await fx.service.submitMove(matchId, host, { kind: 'increment' });
+
+      const view = await getView(fx, matchId, 'spectator');
+      expect(view.isTerminal).toBe(true);
+      expect(view.phase).toBe('gameOver');
+      expect(view.currentActors).toEqual([]);
+      expect(view.outcome).toEqual({
+        kind: 'solo',
+        winners: [host],
+        losers: [guest],
+      });
+
+      const meta = fx.service.getMatchMeta(matchId)!;
+      const table = fx.lobby.getTable(meta.tableId)!;
+      expect(table.status).toBe('finished');
+    });
+  });
+
+  describe('timers', () => {
+    it('scheduled timer fires and onTimer is invoked with the right key', async () => {
+      jest.useFakeTimers();
+      try {
+        const fx = await buildFixture();
+        const { matchId, host } = await startCounterMatch(fx);
+
+        counterKnobs.scheduleTimerOnNextMove = { key: 'tick', at: 0 };
+        const result = await fx.service.submitMove(matchId, host, {
+          kind: 'increment',
+        });
+        expect(result).toEqual({ ok: true });
+
+        // The store's setTimeout has been scheduled with delay=0; advance the
+        // synthetic clock to fire it, then flush the microtask queue that
+        // applyNewState uses to persist the onTimer result.
+        jest.runAllTimers();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const view = await getView(fx, matchId, 'spectator');
+        const raw = (await fx.store.get(matchId)) as {
+          state: CounterState;
+          version: number;
+        } | null;
+        expect(raw?.state.lastTimerKey).toBe('tick');
+        // Two applyNewState calls: the move, then the timer.
+        expect(view.version).toBe(2);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -855,18 +855,27 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
       '@types/react':
         specifier: ^19.0.10
         version: 19.0.10
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
       react:
         specifier: ^19.0.0
         version: 19.0.0
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      ts-jest:
+        specifier: ^29.2.6
+        version: 29.4.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2


### PR DESCRIPTION
## Summary

Adds the first unit-test suites to the repo, establishing a pattern for game modules and covering the match-service core.

### `packages/games-tictactoe/src/server.spec.ts` (td-fd1200)
- 26 tests, 100% line coverage of `server.ts` (97.61% branches).
- Covers `createInitialState` (board shape, X/O assignment via seeded RNG, player-count guard), `handleMove` (valid, taken cell, wrong turn, out-of-bounds, malformed, post-game, unknown actor), `view` (asserted identical for each player + spectator since tic-tac-toe has no hidden info), `outcome` (row/col/both diagonals/draw/mid-game null), and the `isTerminal <-> outcome !== null` SDK invariant.
- Synthetic `GameContext` with fixed seeds — no `Math.random`, no `Date.now`.
- Adds `jest.config.cjs` + `ts-jest`/`@types/jest`/`jest` devDeps so `pnpm --filter @bgo/games-tictactoe test` works. Excludes `*.spec.ts` from `tsc` build so `dist/` stays clean.
- This is the reference pattern other game packages should copy.

### `packages/server/src/match/match.service.spec.ts` (td-1be8e2)
- 11 tests covering `handleMove` happy path (state update, version increment, subscriber notification, events), rejections (out-of-turn, game-reports-ok-false, post-terminal, thrown error → safe internal-error reason, non-participant → ForbiddenException), phase transitions, terminal detection + outcome + `tables.markFinished`, and the `scheduleTimer` -> `onTimer` path with Jest fake timers.
- Uses a minimal in-test `counter-game` fixture (`__fixtures__/counter-game.ts`) with runtime knobs (`failNextMove`, `emitOnNextMove`, `scheduleTimerOnNextMove`, `phaseChangeOnCount`) so the suite has no dependency on any real game package. Real `InMemoryStateStore` + `GamesRegistry` + `TablesService` + `LobbyStore` wired via NestJS `Test.createTestingModule` so the full move -> publish pipeline is exercised.

### New pattern for future game-module tests
Copy the tic-tac-toe approach: a `jest.config.cjs` per package, a `makeCtx()` harness that returns a deterministic `GameContext`, fixed seeds instead of random, and explicit assertions on the five SDK surfaces (`createInitialState`, `handleMove` accept/reject, `view`, `outcome`, `isTerminal <-> outcome`).

## Test plan

- [x] `pnpm --filter @bgo/games-tictactoe test` — 26/26 passing
- [x] `pnpm --filter @bgo/server test` — 11/11 passing
- [x] `pnpm -r typecheck` — clean across all 37 packages
- [x] No `Math.random` / `Date.now` in test code

Tickets: td-fd1200, td-1be8e2

🤖 Generated with [Claude Code](https://claude.com/claude-code)